### PR TITLE
PyPi distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.13.0
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  PyPI:
+    name: Upload to PyPI
+
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,34 @@
+# This tries to build packages, and tests the packages.
+# It runs on every push to branches following the pattern v*.*.*.
+# It makes sure that everything will run when the version is released.
+
+name: Test Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - v*.*.*
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.13.0
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,7 @@
+![Tests](https://img.shields.io/github/actions/workflow/status/zrax/pycdc/linux-ci.yml?branch=master&label=tests&style=flat-square)
+[![PyPI](https://img.shields.io/pypi/v/pycdc?color=blue&style=flat-square)](https://pypi.org/project/pycdc/)
+[![Python](https://img.shields.io/pypi/pyversions/pycdc?color=blue&style=flat-square)](https://pypi.org/project/pycdc/)
+
 # Decompyle++ 
 ***A Python Byte-code Disassembler/Decompiler***
 
@@ -51,7 +55,15 @@ Both tools support Python marshalled code objects, as output from `marshal.dumps
 
 To use this feature, specify `-c -v <version>` on the command line - the version must be specified as the objects themselves do not contain version metadata.
 
-**To use the Python bindings**, run the following Python script:
+**To use the Python bindings**
+
+Ensure the `pycdc` Python package is installed:
+
+- either from source (see [above](#building-and-installing-the-python-package))
+- or from PyPi : `pip install pycdc`
+
+Then, use it as below:
+
 ```python
 import marshal
 from pycdc import decompyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ build-backend = "setuptools.build_meta"
 
 
 [tool.cibuildwheel]
+test-requires = "pytest"
+test-command = "pytest {project}/tests/test_bindings.py"
 skip = [
     "*p36-*", # Skip Python 3.6
     "pp*", # Skip PyPy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,15 @@ readme = "README.md"
 urls.homepage = "https://github.com/zrax/pycdc"
 dynamic = ["version"]
 requires-python = ">3.7.6,<3.11"
+classifiers = [
+    # Specify the Python versions you support here. In particular, ensure
+    # that you indicate whether you support Python 2, Python 3 or both.
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+]
 
 dependencies = []
 

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1,0 +1,20 @@
+import marshal
+
+from pycdc import decompyle
+
+
+def func():
+    a = 6
+    data = foobar(a)
+    return data
+
+
+body = """\
+a = 6
+data = foobar(a)
+return data
+"""
+
+
+def test_marshalled_code():
+    assert decompyle(marshal.dumps(func.__code__)) == body


### PR DESCRIPTION
Hi,

This PR follows #349 and adds GitHub actions to build, test and upload pre-built binaries & source package to PyPI (under the name `pycdc`) for most platforms. This allows end users to simply run:

```bash
pip install pycdc
```

to install the library, without having to clone or build anything in most cases (with the exception of arm based macs and other exotic platforms that need to have pre-installed build environments to run the above command).

There are two new workflow files triggered by hand or by the following events:
- on push to branch `vx.y.z` (version bump branches): build and test python binaries against major platforms
- on releases: build, test and upload binaries & source to PyPI. This one requires manually uploading a first package (usually empty or source dist) to pypi to acquire the `pycdc` name and enabling the [Trusted Publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) feature

I've restricted python versions to 3.7 to 3.10, since I was not able to build the lib for python < 3.7 and python 3.11 doesn't seem well supported atm (in particular, `tests/test_bindings.py` fails with in 3.11). In theory, python 3.11 could be used to run decompile code, but only of lower versions of python at the moment, which might be confusing ? Let me know what you think.

I also took the liberty of adding some shields to the readme to reflect the state of the project (tests / pypi version / installable python versions).